### PR TITLE
match request fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ This repository is a **monorepo of separate npm packages** (no root `package.jso
 |-----------|-----------|-------------|---------|
 | Azure Functions API | `packages/back-end` | `http://127.0.0.1:7071/api` | OKH/OKW listing, blob-backed product data, incidents (Postgres), etc. |
 | Nuxt front end | `packages/front-end` | `http://localhost:3000` | Vue UI |
-| Open Hardware Manager (supply-graph-ai) | *separate clone* | `http://localhost:8001` | Matching / supply-tree API (`POST /v1/api/match`, docs at `/docs`) |
+| Open Hardware Manager (supply-graph-ai) | *separate clone* (often **Docker Compose**) | `http://localhost:8001` | FastAPI matching / supply-tree API (`POST /v1/api/match`, docs at `/docs`) |
 | Mock match API (optional) | `packages/mock-api` | `http://localhost:8001` | Tiny Express stub; **same port as OHM** — use one or the other, not both |
 
 ## Prerequisites
@@ -62,7 +62,7 @@ This repository is a **monorepo of separate npm packages** (no root `package.jso
 - **Azure Functions Core Tools v4** (installed with `packages/back-end` via npm; ensure `func` is on your `PATH` after `npm install`)
 - **Azure CLI** (`az`) — install from [Microsoft’s docs](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli). You need subscription access and permissions for team resources (blob storage, etc.) as appropriate.
 - **PostgreSQL** — only if you use endpoints that query the database (e.g. `/api/incidents`). Configure via `packages/back-end/.env` (see [packages/back-end/README.md](packages/back-end/README.md)).
-- **supply-graph-ai** — Python 3.12, Conda (recommended), and dependencies per that repo’s README ([local dev](https://github.com/helpfulengineering/supply-graph-ai/blob/main/README.md#option-2-local-development-for-active-development) or Docker Compose).
+- **supply-graph-ai** — easiest path is **Docker Desktop** and **`docker compose`** in that repo (service **`ohm-api`** maps **host port 8001**). Alternative: local Python 3.12 / Conda per [supply-graph-ai README](https://github.com/helpfulengineering/supply-graph-ai/blob/main/README.md).
 
 ## 1. Back end (`packages/back-end`)
 
@@ -121,7 +121,28 @@ The front end uses two different configuration mechanisms:
 
 ## 3. Open Hardware Manager — **supply-graph-ai** (matching API)
 
-Clone and run [supply-graph-ai](https://github.com/helpfulengineering/supply-graph-ai) **outside** this repo (for example next to it: `../supply-graph-ai`). Typical local startup from that project:
+Clone [supply-graph-ai](https://github.com/helpfulengineering/supply-graph-ai) **outside** this repo (for example next to it: `../supply-graph-ai`).
+
+### Docker Desktop (typical setup)
+
+With **Docker Desktop** running, from the **supply-graph-ai** repository root:
+
+```bash
+cd /path/to/supply-graph-ai
+cp env.template .env   # if you have not already; edit for storage/API keys as needed
+docker compose up ohm-api
+```
+
+The Compose file publishes the FastAPI app on **host `localhost:8001`** (container service **`ohm-api`**, port mapping `8001:8001`). Confirm it is up:
+
+- **http://localhost:8001/health**
+- **http://localhost:8001/docs**
+
+You can use `docker compose up` instead of `docker compose up ohm-api` if you intend to start the full stack defined in that repo’s `docker-compose.yml`.
+
+### Local Python (no Docker)
+
+For active development inside supply-graph-ai with hot reload:
 
 ```bash
 cd /path/to/supply-graph-ai
@@ -129,11 +150,11 @@ conda create -n supply-graph-ai python=3.12
 conda activate supply-graph-ai
 pip install -r requirements.txt
 pip install -e .
-cp env.template .env   # edit if your team requires storage or API keys
+cp env.template .env
 python run.py
 ```
 
-The HTTP API listens on **`http://localhost:8001`** by default (`API_PORT` in that project’s settings). Interactive docs: **http://localhost:8001/docs**.
+Same default URL: **`http://localhost:8001`** (`API_PORT` in that project’s settings).
 
 ### Wiring project-data-platform-ts ↔ supply-graph-ai
 
@@ -141,9 +162,13 @@ The HTTP API listens on **`http://localhost:8001`** by default (`API_PORT` in th
 |-----------|-------------------|
 | Browser → **Azure Functions** | `BACKEND_URL` / default `baseUrl` → `http://127.0.0.1:7071/api` (or your deployed API URL). |
 | Browser → **OHM** | `VITE_SUPPLY_GRAPH_AI_URL` → base URL only, **no path** (e.g. `http://localhost:8001`). The front end appends **`/v1/api/match`** for match requests. |
+| OKH file URL for match | Optional **`VITE_PUBLIC_OKH_BLOB_BASE`** (default: `https://projdatablobstorage.blob.core.windows.net/okh`). The UI sends **`okh_url`** = `{base}/{fname}` so OHM can fetch the manifest over HTTPS. |
 | OHM → **Azure Blob** | Configure OHM’s `.env` / storage settings per [supply-graph-ai documentation](https://github.com/helpfulengineering/supply-graph-ai) so it can load OKW/OKH data as needed for matching. |
+| **OKH vs OKW in a match call** | This repo sends **OKH** as **`okh_url`**. **OKW** (capability) files are **not** attached by the browser; OHM’s **`OKWService`** loads them from **OHM-configured storage** and matches against the fetched OKH. See **[docs/match-endpoint-integration.md](docs/match-endpoint-integration.md)** (section *OKH + OKW workflow*). |
 
 **Match endpoint:** **`POST {VITE_SUPPLY_GRAPH_AI_URL}/v1/api/match`** — this is the route the Open Hardware Manager exposes; it is **not** the same as the stub in `packages/mock-api` (`POST /v1/match`).
+
+**End-to-end match testing:** Follow **[docs/match-endpoint-integration.md](docs/match-endpoint-integration.md)** for the ordered verification steps (OHM health, blob URL reachability from Docker, Azure Functions, CORS, and curl). Shared client helpers live in **`packages/front-end/utils/ohmMatch.ts`**. To assert the **same JSON body and headers** as the UI against a running OHM, run **`OKH_FNAME=… node scripts/verify-ohm-match.mjs`** from the repo root (see doc §6).
 
 **CORS:** In development, supply-graph-ai typically allows browser calls; if you change origins or run production-like settings, set **`CORS_ORIGINS`** in OHM’s environment so **`http://localhost:3000`** (and/or `http://127.0.0.1:3000`) is allowed.
 

--- a/packages/front-end/pages/products/[id]/supplyTree.vue
+++ b/packages/front-end/pages/products/[id]/supplyTree.vue
@@ -1,7 +1,12 @@
 <script setup lang="ts">
-import { useRouter, useRoute } from "#app";
-import { ref, reactive, computed, onMounted } from "vue";
+import { useRoute } from "#app";
+import { ref, onMounted } from "vue";
 import D3SupplyTree from "../../../components/D3Tree.vue";
+import {
+  buildManufacturingMatchPayload,
+  parseOhmMatchBody,
+  postOhmMatch,
+} from "~/utils/ohmMatch";
 
 const route = useRoute();
 
@@ -9,28 +14,13 @@ const okh = useState("okh");
 
 console.log("Shared product:", okh.value);
 
-
-
 const productFilename = route.params.id as string;
 
 console.log("productFilename", productFilename);
 
-// now you have  route.params.id   → same product id
-const okhData = ref<any>([]);
-const supplyTreeData = ref<any>(null);
 const loading = ref<boolean>(false);
 const error = ref<string | null>(null);
 const selectedOkh = ref<any>(null);
-// API configuration
-const apiBaseUrl = ref(
-  import.meta.env.VITE_API_BASE_URL || "http://localhost:7071/api"
-);
-// Updated to use port 8001 as requested
-const supplyGraphApiUrl = ref(
-  import.meta.env.VITE_SUPPLY_GRAPH_AI_URL || "http://localhost:8001"
-);
-const supplyGraphApiEndpoint = ref("/v1/api/match"); // Path to the versioned supply tree creation endpoint
-
 
 const sendToSupplyGraphAI = async (o: any) => {
   if (!o) {
@@ -58,112 +48,55 @@ const sendToSupplyGraphAI = async (o: any) => {
   error.value = null;
   selectedOkh.value = okhItem;
   try {
-    const originalData = okhItem.originalData || okhItem;
+    const payload = buildManufacturingMatchPayload(productFilename);
 
-      console.log("Preparing to send OKH item to Supply Graph AI:", okhItem);
-      console.log("HOPING FILENAME",okhItem.fname);
-
-      // WARNING! TODO: This is hard coding a recipe. We instatn want this to be the OKH!
-      // TODO: See if we can use our own backend for this....
-      const okh_blobstorage_file_name = "https://projdatablobstorage.blob.core.windows.net/okh";
-
-
-    const parts = productFilename.split('.');
-
-
-    const payload = {
-          "okh_url": `${okh_blobstorage_file_name}/${productFilename}`
-    };
-
-      // We would like to get this data from our backend, instead from
-      // azure, because we have already read this data.
-      // However, I don't think that will work because that system
-      // runs in docker, which does not have access to a local
-      // machine.
-      //
-      // const backend_url = "http://localhost:7071/api/getFile";
-      // const fileType = "okh";
-      // const payload = {
-      //     "okh_url": `${backend_url}/okh/${parts[0]}/${parts[1]}`
-      // };
-
-
-
-    console.log("Enhanced payload for Supply Graph AI (port 8001):", payload);
-    console.log(
-      `Sending request to: ${supplyGraphApiUrl.value}${supplyGraphApiEndpoint.value}`
-    );
-    // Enhanced request to supply-graph-ai endpoint at port 8001
-    const response = await fetch(
-      `${supplyGraphApiUrl.value}${supplyGraphApiEndpoint.value}`,
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Accept: "application/json",
-          // Enhanced headers for better compatibility
-          "User-Agent": "project-data-platform-ts/1.0",
-          "X-Requested-With": "XMLHttpRequest",
-          // Add CORS headers if needed for local development
-          Origin:
-            typeof window !== "undefined"
-              ? window.location.origin
-              : "http://localhost:3000",
-        },
-        mode: "cors", // Explicitly request CORS mode
-        body: JSON.stringify(payload),
-      }
-    );
-
-    console.log(
-      `Supply Graph AI response status: ${response.status} ${response.statusText}`
-    );
+    console.log("OHM match payload:", payload);
+    const response = await postOhmMatch(payload as Record<string, unknown>);
 
     if (!response.ok) {
-      let errorData = null;
+      let errorData: unknown = null;
       try {
         errorData = await response.json();
-      } catch (e) {
-        // Response might not be JSON
+      } catch {
         console.warn("Could not parse error response as JSON");
       }
-
       throw new Error(
-        `Supply Graph AI API error: ${response.status} ${response.statusText}` +
-          (errorData ? ` - ${JSON.stringify(errorData)}` : "")
+        `OHM match error: ${response.status} ${response.statusText}` +
+          (errorData ? ` — ${JSON.stringify(errorData)}` : "")
       );
     }
 
-    // Parse the response from supply graph AI
     const supplyTreeResponse = await response.json();
+    const { solutions } = parseOhmMatchBody(supplyTreeResponse);
 
+    if (!solutions.length) {
+      // HTTP 200 with empty solutions is valid; not a client/transport error.
+      error.value = null;
+      treeData.value = {
+        name: selectedOkh.value?.name || "Supply Tree",
+        children: [{ image: "/okh.png", children: [] }],
+      };
+      return;
+    }
 
-    console.log("Supply Graph AI Response2:", supplyTreeResponse);
-
-    // Clear previous solutions
     const formattedSolutions: any[] = [];
-
-    supplyTreeResponse.data.solutions.forEach((solution: any) => {
-
-      const children = solution.tree.capabilities_used.map((capability: string) => ({
-        name: capability,
+    for (const solution of solutions) {
+      const tree = (solution.tree as Record<string, unknown> | undefined) || {};
+      const capRaw = tree.capabilities_used;
+      const caps = Array.isArray(capRaw) ? capRaw : [];
+      const children = caps.map((capability: unknown) => ({
+        name: String(capability),
         image: "/OKP_icon.png",
       }));
 
-
-      const formattedSolution = {
-        name: solution.facility_name,
+      formattedSolutions.push({
+        name: String(solution.facility_name ?? "Facility"),
         image: "/okw_maker.png",
         class: "test",
-        children: children,
-      };
+        children,
+      });
+    }
 
-      formattedSolutions.push(formattedSolution);
-    });
-
-    console.log("formattedSolutions:", formattedSolutions);
-
-    // Update treeData.value to trigger re-render in D3Tree component
     treeData.value = {
       name: selectedOkh.value?.name || "Supply Tree",
       children: [

--- a/packages/front-end/pages/supply-graph-api.vue
+++ b/packages/front-end/pages/supply-graph-api.vue
@@ -1,5 +1,12 @@
 <script setup lang="ts">
-    import { onMounted, ref, computed } from 'vue';
+import { onMounted, ref } from 'vue';
+import {
+  buildManufacturingMatchPayload,
+  getOhmBaseUrl,
+  OHM_MATCH_PATH,
+  parseOhmMatchBody,
+  postOhmMatch,
+} from '~/utils/ohmMatch';
 
 // Removed data1 and data2 - no mock data needed
 const okhData = ref<any>([]);
@@ -10,9 +17,8 @@ const selectedOkh = ref<any>(null);
 
 // API configuration
 const apiBaseUrl = ref(import.meta.env.VITE_API_BASE_URL || 'http://localhost:7071/api');
-// Updated to use port 8001 as requested
-const supplyGraphApiUrl = ref(import.meta.env.VITE_SUPPLY_GRAPH_AI_URL || 'http://localhost:8001');
-const supplyGraphApiEndpoint = ref('/v1/api/match'); // Open Hardware Manager (supply-graph-ai) match endpoint
+const supplyGraphApiUrl = ref(getOhmBaseUrl());
+const supplyGraphApiEndpoint = ref(OHM_MATCH_PATH);
 
 // Removed fetchData function - no mock data needed
 
@@ -80,9 +86,30 @@ const fetchOkhData = async () => {
 
 // Removed duplicate code - function already completed above
 
-const sendToSupplyGraphAI = async (okhItem) => {
+function solutionsToRelatedComponents(solutions: Record<string, unknown>[]) {
+  return solutions.map((sol, i) => {
+    const tree = (sol.tree as Record<string, unknown> | undefined) || {};
+    const caps = tree.capabilities_used;
+    const capList = Array.isArray(caps)
+      ? caps.map(String)
+      : [];
+    const conf = typeof sol.confidence === 'number' ? sol.confidence : Number(sol.confidence);
+    return {
+      name: String(sol.facility_name ?? `Facility ${i + 1}`),
+      shortDescription: capList.length
+        ? capList.slice(0, 8).join(', ')
+        : `Match type: ${String(sol.match_type ?? 'unknown')}`,
+      supplyRelation:
+        Number.isFinite(conf) && conf > 0
+          ? `confidence ${conf.toFixed(2)}`
+          : undefined,
+    };
+  });
+}
+
+const sendToSupplyGraphAI = async (okhItem: any) => {
   if (!okhItem) {
-    error.value = "No OKH item selected";
+    error.value = 'No OKH item selected';
     return;
   }
 
@@ -91,87 +118,41 @@ const sendToSupplyGraphAI = async (okhItem) => {
   selectedOkh.value = okhItem;
 
   try {
-    console.log('Processing OKH item for Supply Graph AI:', okhItem);
     const originalData = okhItem.originalData || okhItem;
+    const fname = originalData.fname || okhItem.fname;
+    const payload = buildManufacturingMatchPayload(String(fname || ''));
 
-    // const payload = {
-    //   okh_reference: okhItem.id?.toString() || originalData.fname || originalData.id || 'unknown',
-    //   required_quantity: 1,
-    //   deadline: null,
-    //   metadata: {
-    //     name: okhItem.name || originalData.name || originalData.title,
-    //     shortDescription: okhItem.shortDescription || originalData.description || originalData.summary,
-    //     keywords: okhItem.keywords || originalData.keywords || originalData.tags || [],
-    //     maker: okhItem.maker || originalData.maker || originalData.author || originalData.creator,
-    //     whereToFind: okhItem.whereToFind || originalData.whereToFind || originalData.source,
-    //     source: "project-data-platform-ts",
-    //     image: okhItem.image || originalData.image || originalData.imageUrl,
-    //     originalId: originalData.id || originalData.fname,
-    //     dataSource: originalData.dataSource || 'project-data-platform',
-    //     ...originalData
-    //   }
-    // };
-
-  const payload =  {
-  "recipe_id": "8f14e3c4-09f2-4a5e-8bd9-4b5bb5d0a9cd"
-}
-
-    console.log('Enhanced payload for Supply Graph AI (port 8001):', payload);
-    console.log(`Sending request to: ${supplyGraphApiUrl.value}${supplyGraphApiEndpoint.value}`);
-
-    // Enhanced request to supply-graph-ai endpoint at port 8001
-    const response = await fetch(`${supplyGraphApiUrl.value}${supplyGraphApiEndpoint.value}`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'Accept': 'application/json',
-        // Enhanced headers for better compatibility
-        'User-Agent': 'project-data-platform-ts/1.0',
-        'X-Requested-With': 'XMLHttpRequest',
-        // Add CORS headers if needed for local development
-        'Origin': typeof window !== 'undefined' ? window.location.origin : 'http://localhost:3000',
-      },
-      mode: 'cors', // Explicitly request CORS mode
-      body: JSON.stringify(payload),
-    });
-
-    console.log(`Supply Graph AI response status: ${response.status} ${response.statusText}`);
+    console.log('OHM match payload:', payload);
+    const response = await postOhmMatch(payload as Record<string, unknown>);
 
     if (!response.ok) {
-      let errorData = null;
+      let errorData: unknown = null;
       try {
         errorData = await response.json();
-      } catch (e) {
-        // Response might not be JSON
+      } catch {
         console.warn('Could not parse error response as JSON');
       }
-
       throw new Error(
-        `Supply Graph AI API error: ${response.status} ${response.statusText}` +
-        (errorData ? ` - ${JSON.stringify(errorData)}` : '')
+        `OHM match error: ${response.status} ${response.statusText}` +
+          (errorData ? ` — ${JSON.stringify(errorData)}` : '')
       );
     }
 
-    // Parse the response from supply graph AI
     const supplyTreeResponse = await response.json();
-    console.log('Supply Graph AI Response:', supplyTreeResponse);
+    const { solutions } = parseOhmMatchBody(supplyTreeResponse);
 
-    // Enhanced response processing to handle various response formats
     supplyTreeData.value = {
       rootItem: selectedOkh.value,
-      relatedComponents: supplyTreeResponse.components || supplyTreeResponse.related_items || supplyTreeResponse.dependencies || [],
-      supplyChainDepth: supplyTreeResponse.depth || supplyTreeResponse.chain_depth || 1,
-      analysisTimestamp: supplyTreeResponse.creation_time || supplyTreeResponse.timestamp || new Date().toISOString(),
-      analysisMethod: "supply-graph-ai-port-8001",
-      apiResponse: supplyTreeResponse, // Keep full response for debugging
-      requestPayload: payload // Keep request for debugging
+      relatedComponents: solutionsToRelatedComponents(solutions),
+      supplyChainDepth: solutions.length ? Math.max(1, solutions.length) : 0,
+      analysisTimestamp: new Date().toISOString(),
+      analysisMethod: 'open-hardware-manager /v1/api/match',
+      apiResponse: supplyTreeResponse,
+      requestPayload: payload,
     };
-
-
-    console.log('Final Supply Tree Data:', supplyTreeData.value);
-  } catch (err) {
+  } catch (err: unknown) {
     console.error('Error generating supply tree:', err);
-    error.value = `Failed to generate supply tree: ${err.message}`;
+    error.value = `Failed to generate supply tree: ${err instanceof Error ? err.message : String(err)}`;
   } finally {
     loading.value = false;
   }
@@ -193,15 +174,15 @@ const checkSupplyGraphApiAvailability = async () => {
     for (const endpoint of endpoints) {
       try {
         const response = await fetch(`${supplyGraphApiUrl.value}${endpoint}`, {
-          method: 'HEAD',
-          timeout: 1000 // Short timeout for quick check
+          method: 'GET',
+          signal: AbortSignal.timeout(3000),
         });
         if (response.ok) {
           console.log(`Supply Graph AI API is available at endpoint: ${endpoint}`);
           return true;
         }
-      } catch (e) {
-        // Ignore individual endpoint errors and try next
+      } catch {
+        // try next
       }
     }
 

--- a/packages/front-end/utils/ohmMatch.ts
+++ b/packages/front-end/utils/ohmMatch.ts
@@ -1,0 +1,87 @@
+/**
+ * Helpers for calling Open Hardware Manager (supply-graph-ai) POST /v1/api/match
+ * from the browser. See docs/match-endpoint-integration.md.
+ *
+ * Workflow: we send OKH via okh_url; OHM fetches that manifest, loads OKWs from
+ * its own storage (OKWService), applies optional filters, then matches and returns
+ * data.solutions.
+ */
+
+const DEFAULT_OKH_BLOB_BASE = 'https://projdatablobstorage.blob.core.windows.net/okh';
+
+export function getOhmBaseUrl(): string {
+  const raw =
+    import.meta.env.VITE_SUPPLY_GRAPH_AI_URL || 'http://localhost:8001';
+  return raw.replace(/\/$/, '');
+}
+
+export function getPublicOkhBlobBase(): string {
+  const raw = import.meta.env.VITE_PUBLIC_OKH_BLOB_BASE || DEFAULT_OKH_BLOB_BASE;
+  return raw.replace(/\/$/, '');
+}
+
+/**
+ * Manufacturing match: OHM fetches the manifest from this URL.
+ * Use a publicly reachable URL (e.g. team Azure blob). If OHM runs in Docker,
+ * http://localhost:7071/... will NOT reach your host — see integration doc.
+ */
+export function buildManufacturingMatchPayload(fname: string): { okh_url: string } {
+  const base = getPublicOkhBlobBase();
+  const name = (fname || '').replace(/^\/+/, '');
+  if (!name) {
+    throw new Error('Missing OKH file name (fname) for okh_url');
+  }
+  return { okh_url: `${base}/${name}` };
+}
+
+export const OHM_MATCH_PATH = '/v1/api/match';
+
+export function getOhmMatchUrl(): string {
+  return `${getOhmBaseUrl()}${OHM_MATCH_PATH}`;
+}
+
+export type ParsedOhmMatch = {
+  solutions: Record<string, unknown>[];
+  envelope: Record<string, unknown>;
+};
+
+/**
+ * OHM wraps payloads in { status, message, data: { solutions, ... }, metadata }.
+ */
+export function parseOhmMatchBody(json: unknown): ParsedOhmMatch {
+  if (!json || typeof json !== 'object') {
+    return { solutions: [], envelope: {} };
+  }
+  const root = json as Record<string, unknown>;
+  const data = root.data;
+  if (data && typeof data === 'object') {
+    const d = data as Record<string, unknown>;
+    if (Array.isArray(d.solutions)) {
+      return {
+        solutions: d.solutions as Record<string, unknown>[],
+        envelope: root,
+      };
+    }
+  }
+  if (Array.isArray(root.solutions)) {
+    return {
+      solutions: root.solutions as Record<string, unknown>[],
+      envelope: root,
+    };
+  }
+  return { solutions: [], envelope: root };
+}
+
+export async function postOhmMatch(
+  payload: Record<string, unknown>
+): Promise<Response> {
+  return fetch(getOhmMatchUrl(), {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+    },
+    mode: 'cors',
+    body: JSON.stringify(payload),
+  });
+}

--- a/scripts/verify-ohm-match.mjs
+++ b/scripts/verify-ohm-match.mjs
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+/**
+ * Confirms the same POST /v1/api/match request shape the Nuxt app uses
+ * (packages/front-end/utils/ohmMatch.ts) returns HTTP 200 from OHM.
+ * Body is okh_url only; OHM loads OKWs from its storage service server-side.
+ *
+ * Usage:
+ *   OKH_FNAME=some-okh.yml node scripts/verify-ohm-match.mjs
+ *   OKH_URL='https://.../okh/file.yml' node scripts/verify-ohm-match.mjs
+ *
+ * Env (optional, matches Vite):
+ *   VITE_SUPPLY_GRAPH_AI_URL  default http://localhost:8001
+ *   VITE_PUBLIC_OKH_BLOB_BASE default https://projdatablobstorage.blob.core.windows.net/okh
+ */
+
+const OHM_BASE = (
+  process.env.VITE_SUPPLY_GRAPH_AI_URL ||
+  process.env.OHM_BASE ||
+  'http://localhost:8001'
+).replace(/\/$/, '');
+
+const BLOB_BASE = (
+  process.env.VITE_PUBLIC_OKH_BLOB_BASE ||
+  'https://projdatablobstorage.blob.core.windows.net/okh'
+).replace(/\/$/, '');
+
+const fname = process.env.OKH_FNAME?.trim();
+const okhUrl =
+  process.env.OKH_URL?.trim() ||
+  (fname ? `${BLOB_BASE}/${fname.replace(/^\/+/, '')}` : null);
+
+if (!okhUrl) {
+  console.error(
+    'Missing OKH target. Set OKH_URL (full manifest URL) or OKH_FNAME (file name under blob base).'
+  );
+  process.exit(2);
+}
+
+const matchUrl = `${OHM_BASE}/v1/api/match`;
+const payload = { okh_url: okhUrl };
+
+const res = await fetch(matchUrl, {
+  method: 'POST',
+  headers: {
+    Accept: 'application/json',
+    'Content-Type': 'application/json',
+  },
+  body: JSON.stringify(payload),
+});
+
+const text = await res.text();
+let json;
+try {
+  json = JSON.parse(text);
+} catch {
+  json = null;
+}
+
+console.log('Request URL:', matchUrl);
+console.log('Request body:', JSON.stringify(payload));
+console.log('HTTP', res.status, res.statusText);
+
+if (!res.ok) {
+  console.error('Response (truncated):', text.slice(0, 1200));
+  process.exit(1);
+}
+
+const solutionsLen = json?.data?.solutions?.length;
+const total = json?.data?.total_solutions;
+const apiStatus = json?.status;
+
+console.log('Response envelope:', {
+  status: apiStatus,
+  message: json?.message,
+  total_solutions: total,
+  solutions_length: solutionsLen,
+});
+
+if (apiStatus !== 'success') {
+  console.warn(
+    'Warning: HTTP 200 but JSON status is not "success"; check OHM response shape.'
+  );
+  process.exit(1);
+}
+
+console.log('OK: match request matches front-end contract and returned HTTP 200.');
+process.exit(0);


### PR DESCRIPTION
Subject: Fix OHM match integration: valid OKH payloads, response parsing, and docs

**Summary**

Matching failed or looked “broken” mainly because the UI did not speak the same contract as supply-graph-ai’s POST /v1/api/match, and responses were interpreted incorrectly.

**Root causes**

- Invalid request body: The supply-graph test page sent a hardcoded recipe_id (cooking) instead of a manufacturing OKH input. OHM expects exactly one of okh_id / okh_manifest / okh_url, and rejects extra fields (extra = "forbid"), so requests could 422 or hit the wrong domain.
- Wrong response handling: OHM wraps results in { data: { solutions, … } }. The UI looked for top-level fields like components / related_items, so successful 200 responses appeared empty or useless.
- Problematic fetch usage: Setting Origin (and similar) from the client is invalid/forbidden for browsers and did not help CORS.
- Fragile product page: The supply tree view assumed data.solutions always existed and treated HTTP 200 with an empty solution list like a hard failure.
- Path / ops gaps: The real match path is /v1/api/match (not the mock’s /v1/match). Local setup (Docker OHM on 8001, 127.0.0.1 vs localhost for Azure Functions, blob URLs reachable from OHM) was undocumented.


**Fixes**

- Added packages/front-end/utils/ohmMatch.ts: build okh_url from listing fname, postOhmMatch, parseOhmMatchBody.
- Updated supply-graph-api.vue and products/[id]/supplyTree.vue to use that helper, strip bad headers, and parse data.solutions safely.
- Added docs/match-endpoint-integration.md and README updates: env vars, Docker vs local OHM, CORS, OKH vs OKW workflow (OKH from client URL; OKWs loaded in OHM), verification steps.
- Added scripts/verify-ohm-match.mjs to assert the same payload/headers as the UI against a running OHM.
- Stopped treating empty solutions on 200 as a transport error on the supply tree page.